### PR TITLE
feat: add new source

### DIFF
--- a/cmd/source/source.go
+++ b/cmd/source/source.go
@@ -5,12 +5,16 @@ package source
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/mesosphere/dkp-cli-runtime/core/output"
 
 	avmpkg "github.com/d2iq-labs/avm/pkg/avm"
+	"github.com/d2iq-labs/avm/pkg/config"
+	"github.com/d2iq-labs/avm/pkg/types"
 )
 
 func NewCommand(out output.Output) *cobra.Command {
@@ -21,6 +25,7 @@ func NewCommand(out output.Output) *cobra.Command {
 
 	// Subcommands
 	cmd.AddCommand(ListCommand(out))
+	cmd.AddCommand(AddComannd(out))
 
 	return cmd
 }
@@ -41,4 +46,63 @@ func ListCommand(out output.Output) *cobra.Command {
 			return nil
 		},
 	}
+}
+
+var sourceAlias map[string]string = map[string]string{"go": "golang"}
+var defaultVersion map[string]string = map[string]string{"go": "1.19.3"}
+
+// ListCommand creates a new command to list all source
+func AddComannd(out output.Output) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Installs a source",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			avm, err := avmpkg.New(out)
+			if err != nil {
+				return fmt.Errorf("failed to initialize avm: %w", err)
+			}
+
+			defaultSource := avm.GetDefaultSource()
+
+			pluginName, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return fmt.Errorf("Error parsing source name: %v", err)
+			}
+
+			err = defaultSource.InstallPluginVersion(
+				&types.InstallPluginVersionRequest{
+					Name:    sourceAlias[pluginName],
+					Version: defaultVersion[pluginName],
+				},
+			)
+
+			if err != nil {
+				return fmt.Errorf("failed to install plugin: %w", err)
+			}
+
+			cfg := config.DefaultConfig()
+			symlinkPath := filepath.Join(cfg.SourcesDir(), pluginName)
+			sourcePath := filepath.Join(cfg.SourcesDir(), "asdf", "installs", sourceAlias[pluginName], defaultVersion[pluginName], pluginName)
+
+			// Remove symlink if exists, in case we update the version
+			if _, err := os.Lstat(symlinkPath); err == nil {
+				os.Remove(symlinkPath)
+			}
+
+			err = os.Symlink(sourcePath, symlinkPath)
+			if err != nil {
+				return fmt.Errorf("failed to create symlink: %w", err)
+			}
+
+			return nil
+		},
+	}
+
+	var name string
+	var version string
+	cmd.Flags().StringVar(&name, "name", "", "name of the source")
+	cmd.Flags().StringVar(&version, "version", "", "version of the source")
+	cmd.MarkFlagRequired("name")
+
+	return cmd
 }


### PR DESCRIPTION
This makes it possible to add a new source - which is added via asdf for now.

```
go run main.go source add --name go
```

installs go via asdf and creates a symlink to that installation in `$XDG_DATA_HOME/avm/sources/go`

Not sure if we want to go into that direction or not.
If we want to, we should cleanup the `source.go` file and extract that into a proper place.